### PR TITLE
Add gulpfile.js + package-lock.json to files to be removed from packaging zip

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -44,7 +44,9 @@ rm -rf ./*.neon
 rm -rf ./.*.cache
 rm -rf ./psalm.xml
 rm -rf ./package.json
+rm -rf ./package-lock.json
 rm -rf ./Gruntfile.js
+rm -rf ./gulpfile.js
 rm -rf ./composer.lock
 rm -rf ./.netbeans*
 rm -rf ./.php_cs


### PR DESCRIPTION
It could be common that gulp is used, instead of Grunt.
Also, I don't believe the package-lock.json (npm 5+, I think) should be in the zip.